### PR TITLE
docs: update SECURITY/CONTRIBUTING for Euforicio maintainers

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 ## Contributing to Spec Kit
 
-Hi there! We're thrilled that you'd like to contribute to Spec Kit. Contributions to this project are [released](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) to the public under the [project's open source license](LICENSE).
+Hi there! We're thrilled that you'd like to contribute to Spec Kit. Contributions to this project are licensed under the MIT License (see [LICENSE](LICENSE)). All contributions are reviewed by the Euforicio maintainers.
 
 This project is a fork of the original [github/spec-kit](https://github.com/github/spec-kit) with enhancements and improvements by the euforicio organization.
 
@@ -25,7 +25,7 @@ These are one time installations required to be able to test your changes locall
 1. Run linter: `make lint`
 1. Test the CLI functionality with a sample project if relevant
 1. Push to your fork and submit a pull request
-1. Wait for your pull request to be reviewed and merged.
+1. Wait for your pull request to be reviewed and merged by the Euforicio maintainers.
 
 Here are a few things you can do that will increase the likelihood of your pull request being accepted:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -12,7 +12,7 @@ If you believe you have found a security vulnerability in Spec Kit or any reposi
 
 **Please do not report security vulnerabilities through public issues, discussions, or pull requests.**
 
-Instead, please use this repository's "Report a vulnerability" option under the Security tab to open a private advisory to the Euforicio maintainers. If you cannot access that feature, contact the maintainers using the contact information listed for this repository (e.g., in `CODEOWNERS` or the project profile).
+Instead, please use this repository's "Report a vulnerability" option under the Security tab to open a private advisory to the Euforicio maintainers. If you cannot access that feature, please email us at security@euforic.io.
 
 Please include as much of the information listed below as you can to help us better understand and resolve the issue:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,18 +1,18 @@
-Thanks for helping make GitHub safe for everyone.
+Thanks for helping keep Euforicio projects safe for everyone.
 
 # Security
 
-GitHub takes the security of our software products and services seriously, including all of the open source code repositories managed through our GitHub organizations, such as [GitHub](https://github.com/GitHub).
+Euforicio takes the security of Spec Kit and our other open source projects seriously, including all repositories under the Euforicio organization.
 
-Even though [open source repositories are outside of the scope of our bug bounty program](https://bounty.github.com/index.html#scope) and therefore not eligible for bounty rewards, we will ensure that your finding gets passed along to the appropriate maintainers for remediation. 
+While we do not currently run a public bug bounty program, we will ensure that valid security findings are promptly triaged and addressed by the Euforicio maintainers.
 
 ## Reporting Security Issues
 
-If you believe you have found a security vulnerability in any GitHub-owned repository, please report it to us through coordinated disclosure.
+If you believe you have found a security vulnerability in Spec Kit or any repository maintained by Euforicio, please report it to us through coordinated disclosure.
 
-**Please do not report security vulnerabilities through public GitHub issues, discussions, or pull requests.**
+**Please do not report security vulnerabilities through public issues, discussions, or pull requests.**
 
-Instead, please send an email to opensource-security[@]github.com.
+Instead, please use this repository's "Report a vulnerability" option under the Security tab to open a private advisory to the Euforicio maintainers. If you cannot access that feature, contact the maintainers using the contact information listed for this repository (e.g., in `CODEOWNERS` or the project profile).
 
 Please include as much of the information listed below as you can to help us better understand and resolve the issue:
 
@@ -28,4 +28,4 @@ This information will help us triage your report more quickly.
 
 ## Policy
 
-See [GitHub's Safe Harbor Policy](https://docs.github.com/en/site-policy/security-policies/github-bug-bounty-program-legal-safe-harbor#1-safe-harbor-terms)
+We support good-faith security research and coordinated disclosure. We will not pursue or support legal action against security researchers who report vulnerabilities to us in good faith.


### PR DESCRIPTION
This PR updates project docs to reflect Euforicio as the maintainers.

Changes
- SECURITY.md
  - Rebrand from GitHub to Euforicio throughout
  - Switch reporting to private “Report a vulnerability” (Security tab) routed to Euforicio maintainers
  - Add concise good‑faith disclosure statement; remove GitHub-specific safe‑harbor link
- CONTRIBUTING.md
  - Replace GitHub TOS license reference with explicit MIT license reference
  - Note that PRs are reviewed/merged by Euforicio maintainers

No code changes; documentation only.