### PR TITLE
feat(codex): package native Codex template; remove alias

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -113,11 +113,19 @@ jobs:
           mkdir -p /tmp/sdd-copilot-package/.github/prompts
           generate_commands "copilot" "prompt.md" "\$ARGUMENTS" "/tmp/sdd-copilot-package/.github/prompts"
           echo "Created GitHub Copilot package"
+
+          # Create OpenAI Codex package
+          mkdir -p /tmp/sdd-codex-package
+          cp -r /tmp/sdd-package-base/* /tmp/sdd-codex-package/
+          mkdir -p /tmp/sdd-codex-package/.codex/commands
+          generate_commands "codex" "md" "\$ARGUMENTS" "/tmp/sdd-codex-package/.codex/commands"
+          echo "Created OpenAI Codex package"
           
           # Create archive files for each package
           cd /tmp/sdd-claude-package && zip -r /tmp/spec-kit-template-claude.zip . && cd -
           cd /tmp/sdd-gemini-package && zip -r /tmp/spec-kit-template-gemini.zip . && cd -
           cd /tmp/sdd-copilot-package && zip -r /tmp/spec-kit-template-copilot.zip . && cd -
+          cd /tmp/sdd-codex-package && zip -r /tmp/spec-kit-template-codex.zip . && cd -
 
       - name: Upload template packages to release
         run: |
@@ -129,6 +137,7 @@ jobs:
             /tmp/spec-kit-template-claude.zip \
             /tmp/spec-kit-template-gemini.zip \
             /tmp/spec-kit-template-copilot.zip \
+            /tmp/spec-kit-template-codex.zip \
             --clobber
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ The Specify CLI is a fast, single-binary tool written in Go that provides:
 - ✅ **Single Binary** - No dependencies, works everywhere
 - ✅ **Cross-Platform** - Linux, macOS, Windows support
 - ✅ **Fast** - Compiled Go binary with sub-second startup
-- ✅ **AI Assistant Detection** - Automatically detects Claude Code, Gemini CLI
+- ✅ **AI Assistant Detection** - Automatically detects Claude Code, Gemini CLI, and OpenAI Codex
 - ✅ **Environment Validation** - Checks tools, git config, internet connectivity
 - ✅ **Progress Tracking** - Visual progress indicators for all operations
 - ✅ **Error Handling** - Clear, actionable error messages
@@ -143,6 +143,7 @@ The Specify CLI is a fast, single-binary tool written in Go that provides:
 specify init my-project --ai claude
 specify init my-project --ai gemini  
 specify init my-project --ai copilot
+specify init my-project --ai codex
 
 # Initialize in current directory
 specify init --here --ai claude
@@ -203,7 +204,7 @@ Our research and experimentation focus on:
 ## 🔧 Prerequisites
 
 - **Linux/macOS/Windows** 
-- AI coding agent: [Claude Code](https://www.anthropic.com/claude-code), [GitHub Copilot](https://code.visualstudio.com/), or [Gemini CLI](https://github.com/google-gemini/gemini-cli)
+- AI coding agent: [Claude Code](https://www.anthropic.com/claude-code), [GitHub Copilot](https://code.visualstudio.com/), [Gemini CLI](https://github.com/google-gemini/gemini-cli), or [OpenAI Codex](https://github.com/openai/codex)
 - [Git](https://git-scm.com/downloads) (recommended)
 - Internet connection (for template downloads)
 
@@ -245,6 +246,7 @@ You will be prompted to select the AI agent you are using. You can also proactiv
 specify init <project_name> --ai claude
 specify init <project_name> --ai gemini
 specify init <project_name> --ai copilot
+specify init <project_name> --ai codex
 # Or in current directory:
 specify init --here --ai claude
 ```

--- a/internal/cli/feature.go
+++ b/internal/cli/feature.go
@@ -72,7 +72,7 @@ var featureContextCmd = &cobra.Command{
 	Short: "Update agent context files based on feature plan",
 	Long: `Update AI agent context files based on the current feature plan.
 
-Supported agents: claude, gemini, copilot
+Supported agents: claude, gemini, copilot, codex
 If no agent is specified, updates all existing agent context files.
 
 This command will:
@@ -262,4 +262,3 @@ func runFeaturePaths(cmd *cobra.Command, args []string) error {
 
 	return nil
 }
-

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -45,7 +45,7 @@ var (
 )
 
 func init() {
-	initCmd.Flags().StringVar(&aiAssistant, "ai", "", "AI assistant to use: claude, gemini, or copilot")
+    initCmd.Flags().StringVar(&aiAssistant, "ai", "", "AI assistant to use: claude, gemini, copilot, or codex")
 	initCmd.Flags().BoolVar(&ignoreAgentTools, "ignore-agent-tools", false, "Skip checks for AI agent tools like Claude Code")
 	initCmd.Flags().BoolVar(&noGit, "no-git", false, "Skip git repository initialization")
 	initCmd.Flags().BoolVar(&here, "here", false, "Initialize project in the current directory instead of creating a new one")

--- a/internal/services/environment.go
+++ b/internal/services/environment.go
@@ -303,10 +303,10 @@ func (e *EnvironmentService) GetRecommendations(env *models.Environment) []strin
 
 	// Check AI tools
     hasAnyAI := slices.ContainsFunc(models.ListAgents(), func(ai string) bool { return env.IsToolAvailable(ai) })
-	if !hasAnyAI {
-		recommendations = append(recommendations,
-			"Consider installing an AI assistant (Claude Code, Gemini CLI, or GitHub Copilot) for the best experience")
-	}
+    if !hasAnyAI {
+        recommendations = append(recommendations,
+            "Consider installing an AI assistant (Claude Code, Gemini CLI, GitHub Copilot, or OpenAI Codex) for the best experience")
+    }
 
 	return recommendations
 }

--- a/internal/services/github.go
+++ b/internal/services/github.go
@@ -111,26 +111,28 @@ func (g *GitHubService) GetLatestRelease() (*GitHubRelease, error) {
 
 // FindTemplateAsset finds the appropriate template asset for the given AI assistant
 func (g *GitHubService) FindTemplateAsset(release *GitHubRelease, aiAssistant string) (*GitHubAsset, error) {
-	if release == nil {
-		return nil, &models.TemplateError{
-			Type:      models.TemplateNotFound,
-			Assistant: aiAssistant,
-			Message:   "release cannot be nil",
-		}
-	}
+    if release == nil {
+        return nil, &models.TemplateError{
+            Type:      models.TemplateNotFound,
+            Assistant: aiAssistant,
+            Message:   "release cannot be nil",
+        }
+    }
 
-	expectedPattern := fmt.Sprintf("spec-kit-template-%s", aiAssistant)
-	
-	for _, asset := range release.Assets {
-		if strings.Contains(asset.Name, expectedPattern) && strings.HasSuffix(asset.Name, ".zip") {
-			return &asset, nil
-		}
-	}
+    // Try exact match first
+    expectedPattern := fmt.Sprintf("spec-kit-template-%s", aiAssistant)
+    for _, asset := range release.Assets {
+        if strings.Contains(asset.Name, expectedPattern) && strings.HasSuffix(asset.Name, ".zip") {
+            return &asset, nil
+        }
+    }
 
-	// Build available assets list for error message
-	var availableAssets []string
-	for _, asset := range release.Assets {
-		availableAssets = append(availableAssets, asset.Name)
+    // No alias fallback — require a native asset for the requested assistant.
+
+    // Build available assets list for error message
+    var availableAssets []string
+    for _, asset := range release.Assets {
+        availableAssets = append(availableAssets, asset.Name)
 	}
 
 	return nil, &models.TemplateError{

--- a/templates/plan-template.md
+++ b/templates/plan-template.md
@@ -16,7 +16,7 @@
    → Update Progress Tracking: Initial Constitution Check
 4. Execute Phase 0 → research.md
    → If NEEDS CLARIFICATION remain: ERROR "Resolve unknowns"
-5. Execute Phase 1 → contracts, data-model.md, quickstart.md, agent-specific template file (e.g., `CLAUDE.md` for Claude Code, `.github/copilot-instructions.md` for GitHub Copilot, or `GEMINI.md` for Gemini CLI).
+5. Execute Phase 1 → contracts, data-model.md, quickstart.md, agent-specific template file (e.g., `CLAUDE.md` for Claude Code, `.github/copilot-instructions.md` for GitHub Copilot, `GEMINI.md` for Gemini CLI, or `AGENTS.md` for OpenAI Codex).
 6. Re-evaluate Constitution Check section
    → If new violations: Refactor design, return to Phase 1
    → Update Progress Tracking: Post-Design Constitution Check


### PR DESCRIPTION
This PR fixes Codex integration by packaging a native Codex template and removing the copilot alias fallback.

What changed
- Add `.codex/commands/` packaging and upload `spec-kit-template-codex.zip` in release workflow
- Remove codex→copilot template fallback in CLI (strict native asset)
- Update CLI flags/help to include `--ai codex`
- Docs: add Codex examples and clarify plan template (`AGENTS.md`)

Why
- v0.1.1 was missing the action to build and upload Codex templates, so `specify init --ai codex` failed with "no template found for AI assistant 'codex'".

Follow-up
- Cut a new release (e.g., v0.1.2) so the latest release includes `spec-kit-template-codex.zip`.
- Tag and push: `git tag -a v0.1.2 -m "Codex native template" && git push origin v0.1.2`.

Housekeeping
- Deleted tag `v0.1.1` so we can re-cut with the corrected assets.
